### PR TITLE
Use font tags, whitelist the used font tags

### DIFF
--- a/assets/javascripts/bbcode_color_dialect.js
+++ b/assets/javascripts/bbcode_color_dialect.js
@@ -4,9 +4,9 @@
     stop:  "[/color]",
     rawContents: true,
     emitter: function(contents) {
-      var matches = contents.match(/(.+)](.*)/);
+      var matches = contents.match(/(.+)](.*)$/);
       if (matches) {
-        return ['font', {color: matches[1]}, matches[2]];
+        return ['font', {color: matches[1]}].concat(this.processInline(matches[2]));
       }
     }
   });


### PR DESCRIPTION
`style` is hard to validate, so I switched it to use font tags. And actually whitelist the stuff it generates FailFish.

Done now.
![image](https://cloud.githubusercontent.com/assets/627891/4787404/708e24e4-5daa-11e4-8c9f-664b41159c1d.png)
