### PR TITLE
Replace <font> tag, because it was deprecated in HTML 4.01

### DIFF
--- a/assets/javascripts/bbcode_color_dialect.js
+++ b/assets/javascripts/bbcode_color_dialect.js
@@ -4,7 +4,7 @@
 
   function replaceFontColor (text) {
     while (text !== (text = text.replace(/\[color=([^\]]+)\]((?:(?!\[color=[^\]]+\]|\[\/color\])[\S\s])*)\[\/color\]/ig, function (match, p1, p2) {
-      return "<font color='" + p1 + "'>" + p2 + "</font>";
+      return "<span style='color: " + p1 + "'>" + p2 + "</span>";
     })));
     return text;
   }
@@ -18,6 +18,6 @@
 
   Discourse.Dialect.addPreProcessor(replaceFontColor);
   Discourse.Dialect.addPreProcessor(replaceFontBgColor);
-  Discourse.Markdown.whiteListTag('font', 'color');
+  Discourse.Markdown.whiteListTag('span', 'style', /^color:.*$/i);
   Discourse.Markdown.whiteListTag('span', 'style', /^background-color:.*$/i);
 })();

--- a/assets/javascripts/lib/discourse-markdown/bbcode-color.js.es6
+++ b/assets/javascripts/lib/discourse-markdown/bbcode-color.js.es6
@@ -7,7 +7,7 @@ registerOption((siteSettings, opts) => {
 function replaceFontColor(text) {
   text = text || "";
   while (text !== (text = text.replace(/\[color=([^\]]+)\]((?:(?!\[color=[^\]]+\]|\[\/color\])[\S\s])*)\[\/color\]/ig, function (match, p1, p2) {
-    return `<font color='${p1}'>${p2}</font>`;
+    return `<span style='color:${p1}'>${p2}</span>`;
   })));
   return text;
 }
@@ -21,7 +21,13 @@ function replaceFontBgColor(text) {
 }
 
 export function setup(helper) {
-  helper.whiteList(['font[color]']);
+  helper.whiteList({
+    custom(tag, name, value) {
+      if (tag === 'span' && name === 'style') {
+        return /^color:.*$/.exec(value);
+      }
+    }
+  });
   helper.whiteList({
     custom(tag, name, value) {
       if (tag === 'span' && name === 'style') {


### PR DESCRIPTION
I noticed that you had added the tag in an old PR, but I didn't understand very well why.

The `<font>` tag was **deprecated** in **HTML 4.01**. It's discouraged to use this, since it's an obsolete tag.

I'm currently using my version and it works without problems.