### PR TITLE
FIX: chat is now a core plugin

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -8,7 +8,5 @@
 # transpile_js: true
 
 after_initialize do
-  if respond_to?(:discourse_chat)
-    discourse_chat&.enable_markdown_feature('bbcode-color')
-  end
+  chat&.enable_markdown_feature("bbcode-color") if respond_to?(:chat) && SiteSetting.chat_enabled
 end


### PR DESCRIPTION
Also checks that chat is actually enabled before polluting markdown extensions